### PR TITLE
Fixed save callback to call before save OR delete (rather than only on the save branch)

### DIFF
--- a/custom_metadata.php
+++ b/custom_metadata.php
@@ -535,12 +535,19 @@ class custom_metadata_manager {
 	}
 
 	function save_metadata_field( $field_slug, $field, $object_type, $object_id ) {
-		if( isset( $_POST[$field_slug] ) ) {
-			$value = $this->_sanitize_field_value( $field_slug, $field, $object_type, $object_id, $_POST[$field_slug] );
-			$this->_save_field_value( $field_slug, $field, $object_type, $object_id, $value );
-		} else {
-			$this->_delete_field_value( $field_slug, $field, $object_type, $object_id );
-		}
+          $value = null;
+          if( isset( $_POST[$field_slug] ) )
+            $value = $this->_sanitize_field_value( $field_slug, $field, $object_type, $object_id, $_POST[$field_slug] );
+
+          $save_callback = $this->_get_save_callback( $field );
+          if( $save_callback )
+            return call_user_func( $save_callback, $field_slug, $field, $object_type, $object_id, $value );
+
+          if( isset( $value ) ){
+            $this->_save_field_value( $field_slug, $field, $object_type, $object_id, $value );
+          } else {
+            $this->_delete_field_value( $field_slug, $field, $object_type, $object_id );
+          }
 	}
 
 	function get_metadata_field_value( $field_slug, $field, $object_type, $object_id ) {
@@ -777,10 +784,7 @@ class custom_metadata_manager {
 
 	function _save_field_value( $field_slug, $field, $object_type, $object_id, $value ) {
 
-		$save_callback = $this->_get_save_callback( $field );
-
-		if( $save_callback )
-			return call_user_func( $save_callback, $object_type, $object_id, $field_slug, $value );
+		
 
 		if( ! in_array( $object_type, $this->_non_post_types ) )
 			$object_type = 'post';


### PR DESCRIPTION
Also made the argument order match $custom_metadata_manager->
save_metadata_field for ease of calling the default
method. (Essentially I am trying to allow custom save permissions).

This seems like it could break existing code, but it also seems like a better use / definition of save_callback than previously.

This is my callback, does that seem like a reasonable use case for the save callback?
Is it safe to clear the save_callback then recall the default? It seems like this should work, but I dont yet have a grasp on how everything is fitting together.

``` php
function eit_readonly_save_cb($field_slug, $field, $object_type, $object_id, $value){
  global $custom_metadata_manager;
  if(current_user_can('edit_users')){
    $field->save_callback = null;
    $custom_metadata_manager->save_metadata_field( $field_slug, $field, $object_type, $object_id);
  }
}
```

Hope this helps,
Russ
