### PR TITLE
A couple of (suggested) JavaScript fixes.

### DIFF
--- a/js/custom-metadata-manager.js
+++ b/js/custom-metadata-manager.js
@@ -27,9 +27,9 @@
 			});
 		});
 
-		// init upload fields
-		var custom_metadata_file_frame;
 		$custom_metadata_field.on( 'click.custom_metadata', '.custom-metadata-upload-button', function(e) {
+			// init upload fields (on every click)
+			var custom_metadata_file_frame;
 			e.preventDefault();
 
 			var $this = $(this),


### PR DESCRIPTION
If the field is contains hyphens this will break, the above code fixes this.

All cloned inputs had their values set to '', but this affected the buttons also.
