### PR TITLE
Filter taxonomy_checkbox element values

### DIFF
--- a/custom_metadata.php
+++ b/custom_metadata.php
@@ -1320,13 +1320,15 @@ class custom_metadata_manager {
 					break;
 				case 'taxonomy_checkbox' :
 					$terms = get_terms( $field->taxonomy, array( 'hide_empty' => false ) );
+					$value_type = (isset($field->value_type) ? $field->value_type : 'slug');
+					$value_type = (isset($field->value_type) && ($field->value_type == 'slug' || $field->value_type == 'term_id') ? $field->value_type : 'slug');
 					if ( empty( $terms ) ) {
 						printf( __( 'There are no %s to select from yet.', $field->taxonomy ) );
 						break;
 					}
 					foreach ( $terms as $term ) {
 						printf( ' <label for="%s" class="selectit">', esc_attr( $term->slug ) );
-						printf( '<input type="checkbox" name="%s" value="%s" id="%s"%s>', esc_attr( $field_id ), esc_attr( $term->slug ), esc_attr( $term->slug ), checked( in_array( $term->slug, $value ), true, false ) );
+						printf( '<input type="checkbox" name="%s" value="%s" id="%s"%s>', esc_attr( $field_id ), esc_attr( $term->{$value_type} ), esc_attr( $term->slug ), checked( in_array( $term->slug, $value ), true, false ) );
 						echo esc_html( $term->name );
 						echo '</label>';
 					}

--- a/custom_metadata.php
+++ b/custom_metadata.php
@@ -1320,7 +1320,6 @@ class custom_metadata_manager {
 					break;
 				case 'taxonomy_checkbox' :
 					$terms = get_terms( $field->taxonomy, array( 'hide_empty' => false ) );
-					$value_type = (isset($field->value_type) ? $field->value_type : 'slug');
 					$value_type = (isset($field->value_type) && ($field->value_type == 'slug' || $field->value_type == 'term_id') ? $field->value_type : 'slug');
 					if ( empty( $terms ) ) {
 						printf( __( 'There are no %s to select from yet.', $field->taxonomy ) );

--- a/custom_metadata_examples.php
+++ b/custom_metadata_examples.php
@@ -236,6 +236,7 @@ function x_init_custom_fields() {
 			'group' => 'x_metaBox1',
 			'field_type' => 'taxonomy_checkbox',
 			'taxonomy' => 'category',
+			'value_type' => 'term_id', // set to either 'term_id' or 'slug' (defaults to 'slug' if not set)
 			'label' => 'Category checkbox field',
 		) );
 


### PR DESCRIPTION
I've added the ability to pass an option to `taxonomy_checkbox` that allows the checkbox element's value to be set to either the `slug` (which is the current default) or the `term_id`.

I need this functionality for a site that I'm working on, but I'm guessing this could be abstracted with a bit of work to be an option for all element values.

Thoughts?
