### PR TITLE
Changing order of operations in _sanitize_field_value

### DIFF
--- a/custom_metadata.php
+++ b/custom_metadata.php
@@ -1068,7 +1068,17 @@ class custom_metadata_manager {
 
 		// convert date to unix timestamp
 		if ( in_array( $field->field_type, array( 'datepicker', 'datetimepicker', 'timepicker' ) ) ) {
-			$value = strtotime( $value );
+			
+			// if $value is an array, we need to sanitize every value in the array
+			if( is_array( $value ) ) {
+				$result = array();
+				foreach ( $value as $val ) {
+					$result[] = strtotime( $val );
+				}
+				$value = $result;
+			} else {
+				$value = strtotime( $value );
+			}
 		}
 
 		return $value;

--- a/custom_metadata.php
+++ b/custom_metadata.php
@@ -1063,13 +1063,13 @@ class custom_metadata_manager {
 
 		$sanitize_callback = $this->get_sanitize_callback( $field, $object_type );
 
+		if ( $sanitize_callback )
+			return call_user_func( $sanitize_callback, $field_slug, $field, $object_type, $object_id, $value );
+
 		// convert date to unix timestamp
 		if ( in_array( $field->field_type, array( 'datepicker', 'datetimepicker', 'timepicker' ) ) ) {
 			$value = strtotime( $value );
 		}
-
-		if ( $sanitize_callback )
-			return call_user_func( $sanitize_callback, $field_slug, $field, $object_type, $object_id, $value );
 
 		return $value;
 	}


### PR DESCRIPTION
Locally, I made the datepicker field cloneable, but _sanitize_field_value chokes when strtotime() is fed an Array of values. Switching the order of sanitize_callback allows for customized sanitization of these values.
