### PR TITLE
Add original value parameter through sanitize function

### DIFF
--- a/custom_metadata.php
+++ b/custom_metadata.php
@@ -1069,19 +1069,20 @@ class custom_metadata_manager {
 		delete_metadata( $object_type, $object_id, $field_slug, $value );
 	}
 
-	function _sanitize_field_value( $field_slug, $field, $object_type, $object_id, $value ) {
+	function _sanitize_field_value( $field_slug, $field, $object_type, $object_id, $original_value ) {
+		$new_value = $original_value;
 
 		$sanitize_callback = $this->get_sanitize_callback( $field, $object_type );
 
 		// convert date to unix timestamp
 		if ( in_array( $field->field_type, array( 'datepicker', 'datetimepicker', 'timepicker' ) ) ) {
-			$value = strtotime( $value );
+			$new_value = strtotime( $original_value );
 		}
 
 		if ( $sanitize_callback )
-			return call_user_func( $sanitize_callback, $field_slug, $field, $object_type, $object_id, $value );
+			return call_user_func( $sanitize_callback, $field_slug, $field, $object_type, $object_id, $new_value, $original_value );
 
-		return $value;
+		return $new_value;
 	}
 
 	function _metadata_column_content( $field_slug, $field, $object_type, $object_id ) {


### PR DESCRIPTION
Instead of just passing the `$value` through the sanitize function, we are now passing `$original_value` and then setting a value for `$new_value` within the function.

This helps in situations where you might need to alter the original value in a custom callback and not work with just the new value that might not be sanitized properly.

Example: if we're getting a French date, and it's already sanitized then we're left with a null value.  Instead we need to sanitize the original value properly and set the new value that way.