### PR TITLE
Fix type=button selector by wrapping it in square brackets.

### DIFF
--- a/js/custom-metadata-manager.js
+++ b/js/custom-metadata-manager.js
@@ -22,7 +22,7 @@
 
 			id_name = split_id[0] + '-' + instance_num;
 			$clone.attr( 'id', id_name );
-			$clone.insertAfter( $last ).hide().fadeIn().find( ':input' ).not( 'type="button"' ).val(''); // todo: figure out if default value
+			$clone.insertAfter( $last ).hide().fadeIn().find( ':input' ).not( '[type=button]' ).val(''); // todo: figure out if default value
 		});
 
 		// deleting fields


### PR DESCRIPTION
This fixes an issue where new inputs added to `multiple` fields are given the value of the last existing input. 

Prior to this fix, when a new input is added, the JS console shows:

```
Error: Syntax error, unrecognized expression: type="button"
```

Wrapping the `type="button"` selector in square brackets fixes the issue. I also removed the quotes around "button" for consistency with another `[type=button]` selector elsewhere in the file.
