### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "7.4"
           coverage: none
@@ -29,12 +29,12 @@ jobs:
       # Show PHP lint violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register PHP lint violations to appear as file diff comments
-        uses: korelstar/phplint-problem-matcher@v1
+        uses: korelstar/phplint-problem-matcher@cb2b753750ec7bf13a7cde0a476df8c5605bdfb1 # v1.2.0
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register XML violations to appear as file diff comments
-        uses: korelstar/xmllint-problem-matcher@v1
+        uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0 # v1.2.0
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@994bb194a4fefcf39449ccf0f7766a4318f1ac76 # v1
 
       # Lint PHP.
       - name: Lint PHP against parse errors
@@ -56,7 +56,7 @@ jobs:
       # Needed as runs-on: system doesn't have xml-lint by default.
       # @link https://github.com/marketplace/actions/xml-lint
       - name: Lint phpunit.xml.dist
-        uses: ChristophWurst/xmllint-action@v1
+        uses: ChristophWurst/xmllint-action@d18a551aab4728e4af449617638600634d7a48cb # v1
         with:
           xml-file: ./phpunit.xml.dist
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
@@ -65,7 +65,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@994bb194a4fefcf39449ccf0f7766a4318f1ac76 # v1
         with:
           composer-options: "${{ matrix.composer-options }}"
 


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 5
- Repo-level unpinned usage count from the trunk recheck: 7
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Known label limitations:
- `ChristophWurst/xmllint-action` keeps `# v1` because `v1` is the exact tag being pinned; newer `v1.x` tags point to different commits.
- `ramsey/composer-install` keeps `# v1` because `v1` is a branch at this commit; specific `1.x` tags point to different commits.

Verification commands:

```bash
# ChristophWurst/xmllint-action # v1 -> d18a551aab4728e4af449617638600634d7a48cb
gh api repos/ChristophWurst/xmllint-action/commits/v1 --jq '.sha'
# expected: d18a551aab4728e4af449617638600634d7a48cb

# korelstar/phplint-problem-matcher # v1.2.0 -> cb2b753750ec7bf13a7cde0a476df8c5605bdfb1
gh api repos/korelstar/phplint-problem-matcher/commits/v1.2.0 --jq '.sha'
# expected: cb2b753750ec7bf13a7cde0a476df8c5605bdfb1

# korelstar/xmllint-problem-matcher # v1.2.0 -> 1bd292d642ddf3d369d02aaa8b262834d61198c0
gh api repos/korelstar/xmllint-problem-matcher/commits/v1.2.0 --jq '.sha'
# expected: 1bd292d642ddf3d369d02aaa8b262834d61198c0

# ramsey/composer-install # v1 -> 994bb194a4fefcf39449ccf0f7766a4318f1ac76
gh api repos/ramsey/composer-install/commits/v1 --jq '.sha'
# expected: 994bb194a4fefcf39449ccf0f7766a4318f1ac76

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
```
